### PR TITLE
Fixes bug with double endpoint resolving

### DIFF
--- a/src/actions/next.js
+++ b/src/actions/next.js
@@ -1,6 +1,7 @@
 import { getCollectionLink, getCollectionParams } from '../reducers/collection';
 import { getStatus } from '../status';
-import { find, APPEND_MODE, RESOLVED_ENDPOINT } from './find';
+import { find, APPEND_MODE } from './find';
+import { RESOLVED_ENDPOINT } from '../consts';
 import thunkAction from './_thunkAction';
 
 export const NO_MORE_RESULTS = '@@redux_io/NO_MORE_RESULTS';

--- a/test/actions/next.spec.js
+++ b/test/actions/next.spec.js
@@ -14,7 +14,8 @@ import rio, {
   collection,
 } from '../../src';
 import { setStatus, updateStatus, getStatus } from '../../src/status';
-import { APPEND_MODE, RESOLVED_ENDPOINT } from '../../src/actions/find';
+import { APPEND_MODE } from '../../src/actions/find';
+import { RESOLVED_ENDPOINT } from '../../src/consts';
 import  { next } from '../../src/actions/next';
 
 describe('Next action creator', () => {


### PR DESCRIPTION
@vedrani It seems that bug was caused by wrong constant import which led to double endpoint url resolving in `buildEndpoint` method. I opened another PR to keep your git history clean, old PR #8 .