### PR TITLE
fixed headers iterator logic

### DIFF
--- a/src/rsaa/headers.js
+++ b/src/rsaa/headers.js
@@ -33,7 +33,8 @@ export function extractHeaders(resource) {
   const headers = {};
 
   if (isHeadersEntriesSupported(headersInstance)) {
-    for (const header of headersInstance.entries()) {
+    const iterator = headersInstance.entries();
+    for (let header = iterator.next(); !header.done; header = iterator.next()) {
       const [headerName, headerValue] = header.value;
       headers[headerName] = headerValue;
     }


### PR DESCRIPTION
Since transpiled `for...of` iteration for some reason doesn't work (throws exception that it can't iterate through non-iterator object, event though `Headers.entries()` returns iterator object), i had to revert to previous `for` implementation which is tested and works well, despite a bit more code then in `for...of` case.